### PR TITLE
fixes compilation errors, implements lookupVerbDef

### DIFF
--- a/src/language.ml
+++ b/src/language.ml
@@ -60,6 +60,7 @@ module Pirate : LANGUAGE = struct
   type morpheme = Arrr
 
   let name = "Pirate"
+  let native_name = "Arrr"
 
   let stem_verb = function
     | "arrr" -> [("arrr", Arrr)]

--- a/src/main.ml
+++ b/src/main.ml
@@ -1,7 +1,8 @@
 open Language
 open Renderer 
+open Spanish
 
 let () =
   Printexc.record_backtrace true;
-  let module R = Renderer(Pirate) in
+  let module R = Renderer(Spanish) in
   Ui.set_func R.render_verb

--- a/src/swahili.ml
+++ b/src/swahili.ml
@@ -31,16 +31,19 @@ struct
 		| Tense of tense (* there may be no tense, in which case it is an imperative command *)
 		| Root of string * active
 
-	let stem_verb (verb:string) : (string * morpheme) list = 
+	let stem_verb (verb:string) : (string * morpheme) list = Utils.todo ()
 	
 	let morpheme_def (morph:morpheme) : text_chunk list = (Plain (""))::[]
 
 	let morpheme_color (morph:morpheme) : Color.t = 
+        (*
 		match morph with
 		|  -> Color.get 0
 		|  -> Color.get 1
 		|  -> Color.get 2
 		|  -> Color.get 3
+        *)
+        Utils.todo ()
 
 	let translate (parseList:(string * morpheme) list) : translation_result = LanguageNotSupported
 

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -11,5 +11,9 @@ let rec intersperse x = function
 
 let log' x = log x; x
 
+let option_map f = function
+  | Some(x) -> Some(f x)
+  | None -> None
+
 let todo () =
   Js.Exn.raiseError "TODO"

--- a/src/utils.mli
+++ b/src/utils.mli
@@ -3,4 +3,5 @@ val id : 'a -> 'a
 val intersperse : 'a -> 'a list -> 'a list
 val log : 'a -> unit
 val log' : 'a -> 'a
+val option_map : ('a -> 'b) -> 'a option -> 'b option
 val todo : unit -> 'a


### PR DESCRIPTION
this is a pr since stuff like the `Utils.todo ()` in

https://github.com/cassandra-b/uproot/blob/7dc577002d9da7f0cc93daa8ba23fcf88d9e235d/src/spanish.ml#L253

should be changed